### PR TITLE
externalize stylesheet import

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@ A simple React scrubber component with touch controls, styling, and event handle
 The code for the above demo can be found inside the repository in the '/demo' folder.
 
 ## Dependencies
-React is listed as a peer dependency. React should be added as a dependency to your project.
-The component imports it's styling from a ".css" file so you'll need to have webpack set up to handle css imports. The typical combination of `style-loader` and `css-loader` works great!
+React is listed as a peer dependency. React should be added as a dependency to your project. The component provides its styling with a CSS stylesheet (`scrubber.css`) file, so you'll need to import it and have webpack set up to handle css imports. The typical combination of `style-loader` and `css-loader` works great!
 
 ## Usage
 ```js
 import  React, { Component } from  'react';
 import { Scrubber, ScrubberProps } from 'react-scrubber';
 // Note: ScrubberProps is a TypeScript interface and is not used for JS projects
+
+import 'react-scrubber/lib/scrubber.css'
 
 class App extends Component {
   state = {

--- a/demo/src/index.tsx
+++ b/demo/src/index.tsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import { Scrubber } from 'react-scrubber';
 
+import 'react-scrubber/lib/scrubber.css';
 import './index.css';
 
 class App extends Component {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,6 @@
 import React, { Component, createRef } from 'react';
 import fromEntries from 'object.fromentries';
 
-import './scrubber.css';
-
 const clamp = (min: number, max: number, val: number): number => Math.min(Math.max(min, val), max);
 const round = (val: number, dp: number) => parseFloat(val.toFixed(dp));
 


### PR DESCRIPTION
hi! i appreciate your work on this module. `react-scrubber` made it quite pleasant for me to develop a react-based video player.

i've faced one issue: Next.js (which i use) has issues when dependencies import CSS stylesheets by themselves, that is, if a javascript module from `node_modules` imports a CSS file from, again, `node_modules`.

that got me thinking, and it's possibly easier for most projects to manually import the stylesheet in the application code rather than having dependencies do it. some apps use module splitting, others have monolithic CSS stylesheets, and so forth.