### PR TITLE
Custom start/end markers with custom classNames

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,5 +61,5 @@ class App extends Component {
 | onScrubStart | function | No | Called on mouse down or touch down
 | onScrubEnd | function | No | Called on mouse up or touch up while scrubbing
 | onScrubChange | function | No | Called on mouse move while scrubbing
-| markers | number[] | No | Sets yellow indicators across the bar
+| markers | Array<number | { start: number, end?: number, className?: string }> | No | Adds yellow indicators to the scrubber bar
 | custom props | any | No | Any other props will be applied to the outermost 'scrubber' div

--- a/demo/src/index.css
+++ b/demo/src/index.css
@@ -4,6 +4,19 @@ body {
     color: #AAA;
 }
 
+code {
+    background: #3F3F3F;
+    padding: 2px 4px;
+    border-radius: 4px;
+    line-height: 1.8em;
+}
+
+code.codeblock {
+    white-space: pre-wrap;
+    display: block;
+    line-height: initial;
+}
+
 .title {
     text-align: center;
 }
@@ -108,4 +121,12 @@ body {
     grid-template-columns: 50% 50%;
     text-align: center;
     margin: 10px 0;
+}
+
+.scrubber .bar__marker.type-1 {
+    background: #ED269D;
+}
+
+.scrubber .bar__marker.type-2 {
+    background: #004A09;
 }

--- a/demo/src/index.tsx
+++ b/demo/src/index.tsx
@@ -73,6 +73,11 @@ class App extends Component {
                     <div className="block">
                         <div className="description">
                             Although this is a generic scrubber, there is support for an optional buffer bar and arbitrary markers.
+                            <br />
+                            <br />
+                            Markers can be either a number or an object
+                            containing <code>{`{ start: number, end: number, className: string }`}</code> where <code>end</code> and <code>className</code> are
+                            optional. For numerical markers, or markers with no end point specified, a default width will be applied.
                         </div>
                         <div className="scrubber-container" style={{ height: '20px' }}>
                             <Scrubber
@@ -80,9 +85,32 @@ class App extends Component {
                                 max={100}
                                 value={40}
                                 bufferPosition={75}
-                                markers={[69, 88]}
+                                markers={[
+                                    { start: 10, end: 20, className: 'type-1' },
+                                    { start: 24, end: 34, className: 'type-2' },
+                                    { start: 70, end: 84, className: 'type-1' },
+                                    { start: 42 },
+                                    74,
+                                    88,
+                                ]}
                             />
                         </div>
+                        <code className="codeblock" style={{ marginTop: '10px' }} >{
+`<Scrubber
+    min={0}
+    max={100}
+    value={40}
+    bufferPosition={75}
+    markers={[
+        { start: 10, end: 20, className: 'type-1' },
+        { start: 24, end: 34, className: 'type-2' },
+        { start: 70, end: 84, className: 'type-1' },
+        { start: 42 },
+        74,
+        88,
+    ]}
+/>`
+                        }</code>
                     </div>
                     <div className="block">
                         <div className="description">

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,8 @@ const round = (val: number, dp: number) => parseFloat(val.toFixed(dp));
 // Use Object.fromEntries when available
 const filter = (object: Object, fn: (key: string, val: any) => boolean) => fromEntries(Object.entries(object).filter(([key, val]) => fn(key, val)));
 
+type Marker = { start: number, end?: number, className?: string };
+
 export type ScrubberProps = {
     className?: string,
     value: number;
@@ -17,7 +19,7 @@ export type ScrubberProps = {
     onScrubStart?: (value: number) => void;
     onScrubEnd?: (value: number) => void;
     onScrubChange?: (value: number) => void;
-    markers?: number[];
+    markers?: Array<number | Marker>;
     [key: string]: any;
 };
 
@@ -155,8 +157,42 @@ export class Scrubber extends Component<ScrubberProps> {
         const { vertical, markers } = this.props;
         if (markers) {
             return markers.map((value, index) => {
-                const valuePercent = this.getValuePercent(value);
-                return <div key={index} className="bar__marker" style={{ [vertical ? 'bottom' : 'left']: `${valuePercent}%` }} />
+                let className = "bar__marker";
+                const markerStyle: React.CSSProperties = {};
+
+                if (typeof value === 'number') {
+                    const valuePercent = this.getValuePercent(value);
+                    if (vertical) {
+                        markerStyle.bottom = `${valuePercent}%`;
+                    } else {
+                        markerStyle.left = `${valuePercent}%`;
+                    }
+                } else {
+                    const startPercent = this.getValuePercent(value.start);
+                    const endPercent = value.end && this.getValuePercent(value.end);
+
+                    if (vertical) {
+                        markerStyle.bottom = `${startPercent}%`;
+                        
+                        if (endPercent) {
+                            markerStyle.top = `${100 - parseFloat(endPercent)}%`;
+                            markerStyle.height = 'unset';
+                        }
+                    } else {
+                        markerStyle.left = `${startPercent}%`;
+                        
+                        if (endPercent) {
+                            markerStyle.right = `${100 - parseFloat(endPercent)}%`;
+                            markerStyle.width = 'unset';
+                        }
+                    }
+
+                    if (value.className) {
+                        className = `${className} ${value.className}`;
+                    }
+                }
+
+                return <div key={index} className={className} style={markerStyle} />
             }
             );
         }

--- a/src/scrubber.css
+++ b/src/scrubber.css
@@ -76,6 +76,7 @@
 .scrubber .bar__marker {
   position: absolute;
   background: rgb(240, 205, 5);
+  z-index: 1;
 }
 
 .scrubber.horizontal .bar__marker {


### PR DESCRIPTION
Adds support for objects in the Markers array that allow setting a start, end, and custom class name.

![image](https://user-images.githubusercontent.com/9058133/184693748-bc0738af-8dd7-4d35-993f-8e3828103980.png)

Resolves https://github.com/nick-michael/react-scrubber/issues/23